### PR TITLE
Added const to remove warnings

### DIFF
--- a/PIR.cpp
+++ b/PIR.cpp
@@ -17,7 +17,7 @@
 
 #include "PIR.h"
 
-PIR::PIR(short pin, void (*onStateChange)(PirInfo* sender), char* name) {
+PIR::PIR(short pin, void (*onStateChange)(PirInfo* sender), const char* name) {
     this->_initialized = false;
     this->_sender = new PirInfo { pin, LOW, name };
     this->onStateChange = onStateChange;

--- a/PIR.h
+++ b/PIR.h
@@ -37,7 +37,7 @@ struct PirInfo {
     /**
      * The name of the PIR.
      */
-    char* name;
+    const char* name;
 };
 
 /**
@@ -53,7 +53,7 @@ public:
      * be NULL.
      * @param name The name of the PIR. Can be NULL.
      */
-    PIR(short pin, void (*onStateChange)(PirInfo* sender), char* name);
+    PIR(short pin, void (*onStateChange)(PirInfo* sender), const char* name);
 
     /**
      * Gets whether or not the PIR is initialized.


### PR DESCRIPTION
Hi, just a quick PR to clear compiler warning `warning: deprecated conversion from string constant to 'char*'`